### PR TITLE
Handle symlink for `verify`

### DIFF
--- a/src/generics/filesystem_handlers/os_filesystem_elements.c
+++ b/src/generics/filesystem_handlers/os_filesystem_elements.c
@@ -128,9 +128,9 @@ int get_wfile_stat_data(
   }
 
 #ifdef MAC_OS_X
-  res = lstat(locencfn, &stat_data->st_data);
+  res = stat(locencfn, &stat_data->st_data);
 #else
-  res = lstat64(locencfn, &stat_data->st_data);
+  res = stat64(locencfn, &stat_data->st_data);
 #endif
   free(locencfn);
 #endif


### PR DESCRIPTION
The tool uses `lstat()` to obtain the file size of a symbolic link itself instead of the file it refers to, which is what the hash functions operate on.